### PR TITLE
TVG-1 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   TVGUIDE_DB: ${{ secrets.TVGUIDE_DB }}
+  ENV: testing
 
 jobs:
   Run-Tests:

--- a/database/DatabaseService.py
+++ b/database/DatabaseService.py
@@ -186,7 +186,8 @@ class DatabaseService:
             event = {'show': guide_show.to_dict(), 'message': 'Unable to process this episode.', 'error': str(err)}
             hermes.dispatch('show_not_processed', guide_show.message_string(), err)
 
-        log_database_event(event)
+        if os.getenv('ENV') != 'testing':
+            log_database_event(event)
         return event
 
 # SEARCH LIST

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from dotenv import load_dotenv
 import unittest
 import json
+import os
 
 from database.DatabaseService import DatabaseService
 from database.models.GuideShow import GuideShow
@@ -17,6 +18,7 @@ class TestDatabase(unittest.TestCase):
     def setUpClass(self) -> None:
         super().setUpClass()
         load_dotenv('.env')
+        os.environ['ENV'] = 'testing'
         self.database_service = DatabaseService(mongo_client().get_database('test'))
 
         with open('tests/test_data/recorded_shows.json') as fd:


### PR DESCRIPTION
### Ticket
[TVG-1](https://ng-glintech-part1.atlassian.net/browse/TVG-1)

### Description
Logging the database events to a JSON file would either cause tests to fail if they were being run by the CI (since the JSON file would not exist) or would add the events from local tests to the local JSON file. 
This adds an environment variable when tests are being run to ensure that the events from the tests don't get written to the JSON file

### Commits
- [Log DB event if not testing](https://github.com/nGin482/TVGuide/commit/4486b2ccf6a77950aa2a7ef8386c8cfac4546a0b)

### Environment Variable changes
- ENV: testing

[TVG-1]: https://ng-glintech-part1.atlassian.net/browse/TVG-1?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ