### PR TITLE
TVG-5/delete recorded show

### DIFF
--- a/database/DatabaseService.py
+++ b/database/DatabaseService.py
@@ -103,6 +103,14 @@ class DatabaseService:
             return_document=ReturnDocument.AFTER
         )
 
+    def delete_recorded_show(self, show: str):
+        """
+        Remove the given `show` from the RecordedShow collection
+        """
+        self.recorded_shows_collection.find_one_and_delete(
+            {'show': show}
+        )
+
     def backup_recorded_shows(self):
         """
         Create a local backup of the `RecordedShows` collection by storing data locally in JSON files

--- a/tests/test_data/recorded_shows.json
+++ b/tests/test_data/recorded_shows.json
@@ -260,5 +260,27 @@
                 ]
             }
         ]
+    },
+    {
+        "show": "Test Delete",
+        "seasons": [
+            {
+                "season_number": "1",
+                "episodes": [
+                    {
+                        "episode_number": 1,
+                        "episode_title": "Pilot",
+                        "alternative_titles": [],
+                        "summary": "",
+                        "channels": [
+                            "GEM"
+                        ],
+                        "air_dates": [
+                            "15/04/2020"
+                        ]
+                    }
+                ]
+            }
+        ]
     }
 ]

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -279,6 +279,16 @@ class TestDatabase(unittest.TestCase):
         print(reminders[1].notification())
         # with self.assertRaises(IndexError) as exception_context:
         #     reminders[1].compare_reminder_interval()
+
+    def test_delete_recorded_show_succeeds(self):
+
+        shows_count_before = len(self.database_service.get_all_recorded_shows())
+
+        self.database_service.delete_recorded_show('Test Delete')
+
+        shows_count_after = len(self.database_service.get_all_recorded_shows())
+
+        self.assertEqual(shows_count_after, shows_count_before - 1)
     
 
     @classmethod


### PR DESCRIPTION
### Ticket
[TVG-5](https://ng-glintech-part1.atlassian.net/browse/TVG-5)

### Description
The API will expose an endpoint for users to be able to delete a Recorded Show from the UI. However, the DatabaseService had no implementation to delete a Recorded Show from the collection.
This PR introduces the handling necessary to delete a given Recorded Show.

### ENV variable changes
N/A

[TVG-5]: https://ng-glintech-part1.atlassian.net/browse/TVG-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ