### PR TITLE
[TVG-9] Duplicate Reminders

### DIFF
--- a/database/models/GuideShow.py
+++ b/database/models/GuideShow.py
@@ -117,7 +117,7 @@ class GuideShow:
         Returns `None` if no reminder has been set for the show.
         """
         reminder = database_service.get_one_reminder(self.title)
-        if reminder is not None and reminder.compare_reminder_interval(self):
+        if reminder is not None and reminder.compare_reminder_interval(self) and 'HD' not in self.channel:
             reminder.airing_details = (self.channel, self.time)
             reminder.calculate_notification_time()
             self.reminder = reminder


### PR DESCRIPTION
### Ticket
[TVG-9](https://ng-glintech-part1.atlassian.net/browse/TVG-9)

### Description
For shows that air on a regular channel as well as a HD channel, duplicate reminders would be created. This is unnecessary as only one channel would be watched at the one time.
This PR limits the reminders so that only those on the regular channel would be created.

### ENV variable changes
None

[TVG-9]: https://ng-glintech-part1.atlassian.net/browse/TVG-9?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ