### PR TITLE
TVG-19 / Discord messages too long

### DIFF
--- a/aux_methods/helper_methods.py
+++ b/aux_methods/helper_methods.py
@@ -187,3 +187,17 @@ def build_episode(show_title: str, channel: str, time: datetime, season_number: 
             'episode_title': Validation.format_episode_title(episode_title)
         })
     return episodes
+
+def split_message_by_time(message: str):
+    """
+    Use regex to search for any show starting between 12:00 and 13:00 in the given `message`.
+    Split the given message into two substrings:\n
+    all shows from 00:00 to 12:59\n
+    all shows from 13:00 to 23:59.
+    """
+
+    am_index = re.search(r"12:[0-5][0-9]", message).start()
+    am_message = message[0:am_index]
+    pm_message = message[am_index+1:]
+
+    return [am_message, pm_message]

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 from apscheduler.triggers.cron import CronTrigger
 from discord import TextChannel
+from discord.errors import HTTPException
 from dotenv import load_dotenv
 from requests import get
 import os
@@ -54,6 +55,16 @@ async def send_main_message(database_service: DatabaseService):
         await tvguide_channel.send(guide_message)
         await tvguide_channel.send(reminder_message)
         await ngin.send(compose_events_message())
+    except HTTPException as error:
+        if 'In content: Must be 2000 or fewer in length' in error.text:
+            bbc_index = guide_message.find('\nBBC:\n')
+            fta_message = guide_message[0:bbc_index]
+            bbc_message = guide_message[bbc_index+1]
+            
+            await tvguide_channel.send(fta_message)
+            await tvguide_channel.send(bbc_message)
+            await tvguide_channel.send(reminder_message)
+            await ngin.send(compose_events_message())
     except AttributeError:
         await ngin.send('The channel resolved to NoneType so the message could not be sent')
 

--- a/services/hermes/commands.py
+++ b/services/hermes/commands.py
@@ -6,7 +6,7 @@ from zipfile import ZipFile
 import os
 import re
 
-from aux_methods.helper_methods import show_list_message, parse_date_from_command, compose_events_message
+from aux_methods.helper_methods import show_list_message, parse_date_from_command, compose_events_message, split_message_by_time
 from config import database_service, scheduler
 from data_validation.validation import Validation
 from database.models.RecordedShow import RecordedShow
@@ -57,11 +57,15 @@ async def send_guide(ctx: Context):
             fta_message = guide_message[0:bbc_index]
             bbc_message = guide_message[bbc_index+1]
 
-            await ctx.send(fta_message)
+            if len(fta_message) > 2000:
+                fta_am_message, fta_pm_message = split_message_by_time(fta_message)
+                await ctx.send(fta_am_message)
+                await ctx.send(fta_pm_message)
+            else:
+                await ctx.send(fta_message)
+
             if len(bbc_message) > 2000:
-                bbc_am_index = re.search(r"12:[0-5][0-9]", bbc_message).start()
-                bbc_am_message = bbc_message[0:bbc_am_index]
-                bbc_pm_message = bbc_message[bbc_am_index+1:]
+                bbc_am_message, bbc_pm_message = split_message_by_time(bbc_message)
                 await ctx.send(bbc_am_message)
                 await ctx.send(bbc_pm_message)
             else:

--- a/services/hermes/commands.py
+++ b/services/hermes/commands.py
@@ -1,8 +1,10 @@
 from datetime import datetime
 from discord import Message, File
 from discord.ext.commands import Context
+from discord.errors import HTTPException
 from zipfile import ZipFile
 import os
+import re
 
 from aux_methods.helper_methods import show_list_message, parse_date_from_command, compose_events_message
 from config import database_service, scheduler
@@ -46,8 +48,27 @@ async def send_guide(ctx: Context):
     fta_list = search_free_to_air(database_service)
     bbc_list = search_bbc_australia(database_service)
     guide_message, reminders_message = run_guide(database_service, fta_list, bbc_list, scheduler)
-    await ctx.send(guide_message)
-    await ctx.send(reminders_message)
+    ngin = await hermes.fetch_user(int(os.getenv('NGIN')))
+    try:
+        await ctx.send(guide_message)
+    except HTTPException as error:
+        if 'In content: Must be 2000 or fewer in length' in error.text:
+            bbc_index = guide_message.find('\nBBC:\n')
+            fta_message = guide_message[0:bbc_index]
+            bbc_message = guide_message[bbc_index+1]
+
+            await ctx.send(fta_message)
+            if len(bbc_message) > 2000:
+                bbc_am_index = re.search(r"12:[0-5][0-9]", bbc_message).start()
+                bbc_am_message = bbc_message[0:bbc_am_index]
+                bbc_pm_message = bbc_message[bbc_am_index+1:]
+                await ctx.send(bbc_am_message)
+                await ctx.send(bbc_pm_message)
+            else:
+                await ctx.send(bbc_message)
+    finally:
+        await ctx.send(reminders_message)
+        await ngin.send(compose_events_message())
 
 @hermes.command()
 async def send_guide_record(ctx: Context, date_to_send: str):


### PR DESCRIPTION
### Ticket
[TVG-19](https://natalie-g-projects.atlassian.net/browse/TVG-19)

### Description
On Saturday 23 December 2023, the guide message was not able to be sent via Discord because the message was too long. This is most likely due to BBC First running all episodes of Death in Paradise.

This PR splits the message string into FTA and BBC messages. If either of those are too long, it splits the message again by time.

### ENV variable changes
None

[TVG-19]: https://natalie-g-projects.atlassian.net/browse/TVG-19?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ