### PR TITLE
TVG-21 / Fix index for message splicing

### DIFF
--- a/aux_methods/helper_methods.py
+++ b/aux_methods/helper_methods.py
@@ -8,6 +8,7 @@ from log import read_events
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from database.models.GuideShow import GuideShow
+    from database.models.SearchItem import SearchItem
 
 def format_time(time):
     """
@@ -65,9 +66,9 @@ def format_title(title: str):
 
     return title
 
-def show_list_message(shows_list: list[str]):
+def show_list_message(search_list: list[SearchItem]):
     """Return a message-friendly version of the shows being searched for"""
-    return '\n'.join(shows_list)
+    return '\n'.join([search_item.show for search_item in search_list])
 
 def check_show_titles(show):
     if type(show) is str:
@@ -198,6 +199,6 @@ def split_message_by_time(message: str):
 
     am_index = re.search(r"12:[0-5][0-9]", message).start()
     am_message = message[0:am_index]
-    pm_message = message[am_index+1:]
+    pm_message = message[am_index:]
 
-    return [am_message, pm_message]
+    return am_message, pm_message

--- a/main.py
+++ b/main.py
@@ -57,7 +57,7 @@ async def send_main_message(database_service: DatabaseService):
         if 'In content: Must be 2000 or fewer in length' in error.text:
             bbc_index = guide_message.find('\nBBC:\n')
             fta_message = guide_message[0:bbc_index]
-            bbc_message = guide_message[bbc_index+1]
+            bbc_message = guide_message[bbc_index:]
             
             if len(fta_message) > 2000:
                 fta_am_message, fta_pm_message = split_message_by_time(fta_message)

--- a/services/hermes/commands.py
+++ b/services/hermes/commands.py
@@ -55,7 +55,7 @@ async def send_guide(ctx: Context):
         if 'In content: Must be 2000 or fewer in length' in error.text:
             bbc_index = guide_message.find('\nBBC:\n')
             fta_message = guide_message[0:bbc_index]
-            bbc_message = guide_message[bbc_index+1]
+            bbc_message = guide_message[bbc_index:]
 
             if len(fta_message) > 2000:
                 fta_am_message, fta_pm_message = split_message_by_time(fta_message)
@@ -90,7 +90,7 @@ async def revert_tvguide(ctx: Context, date_to_delete: str = None):
     # else, search for today's date
     # if none found, send message "could not find TVGuide message"
     
-    revert_database_tvguide(database_service)
+    # revert_database_tvguide(database_service)
     message_to_delete = None
     messages: list[Message] = await ctx.history(limit=5).flatten()
     for message in messages:


### PR DESCRIPTION
### Ticket
[TVG-21](https://natalie-g-projects.atlassian.net/browse/TVG-21)

### Description
With the recent change in [TVG-19](https://natalie-g-projects.atlassian.net/browse/TVG-29) to fix messages being too long to send, messages were split into the service and if necessary by time as well. However, the index for splicing the message was incorrect and resulted in missing starting characters. This PR resolves the issue.

### ENV variable changes
None

[TVG-21]: https://natalie-g-projects.atlassian.net/browse/TVG-21?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TVG-19]: https://natalie-g-projects.atlassian.net/browse/TVG-19?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ