### PR TITLE
TVG-22 / Web process blocking discord

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 # TODO: Modify this Procfile to fit your needs
 worker: python main.py
-web: gunicorn api:app
+<!-- web: gunicorn api:app -->

--- a/fly.toml
+++ b/fly.toml
@@ -8,8 +8,3 @@ primary_region = "syd"
 
 [build]
   builder = "paketobuildpacks/builder:base"
-
-[http_service]
-  internal_port = 5000
-  force_https = true
-  min_machines_running = 0


### PR DESCRIPTION
### Ticket
[TVG-22](https://natalie-g-projects.atlassian.net/browse/TVG-22)

### Description
With the web process in the Procfile and the http-service in the fly.toml file, the web process is the default process run, blocking Discord from picking up commands. This PR will only run the worker process. However, this change will need to be looked at once ready to run the API in prod.

### ENV variable changes
None

[TVG-22]: https://natalie-g-projects.atlassian.net/browse/TVG-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ