### PR TITLE
[TVG-26]  Check RecordedShows when creating Remindes via API

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@ fly.toml
 /.github
 /Project-BackUp
 /tests/misc
+/dev-data
 /txt
 /log
 /episode_search_results

--- a/api.py
+++ b/api.py
@@ -120,7 +120,7 @@ def get_reminders():
 def reminders():
     reminder = request.json
     show: str = reminder['show']
-    show_check = show in database_service.get_search_list()
+    show_check = show in [show.title for show in database_service.get_all_recorded_shows()]
     reminder_check = database_service.get_one_reminder(show)
     if not show_check:
         return {'message': f'{show} is not being searched for'}, 400

--- a/api.py
+++ b/api.py
@@ -129,7 +129,10 @@ def reminders():
     new_reminder = Reminder.from_database(reminder)
     try:
         database_service.insert_new_reminder(new_reminder)
-        return [reminder.to_dict() for reminder in database_service.get_all_reminders()]
+        return {
+            'message': f'Your reminder for {show} has been created',
+            'reminders': [reminder.to_dict() for reminder in database_service.get_all_reminders()]
+        }
     except DatabaseError as err:
         return {'message': f'An error occurred creating the reminder for {show}', 'error': str(err)}, 500
     


### PR DESCRIPTION
### Ticket
[TVG-26](https://natalie-g-projects.atlassian.net/browse/TVG-26)

### Description
The controller for creating reminders currently checks the search list to ensure a reminder is created for a valid show. However, a reminder could be created for a show that doesn't appear in the search list, such as Transformers: Prime.

There's also an unrelated change in this PR for adding the `/dev-data` directory to the `.dockerignore` file.

### ENV variable changes
None

[TVG-26]: https://natalie-g-projects.atlassian.net/browse/TVG-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ