### PR TITLE
[TVG-27]  Compose Events message function receives None

### DIFF
--- a/main.py
+++ b/main.py
@@ -76,7 +76,7 @@ async def send_main_message(database_service: DatabaseService):
         await ngin.send('The channel resolved to NoneType so the message could not be sent')
     finally:
         await tvguide_channel.send(reminder_message)
-        await ngin.send(compose_events_message(fta_list.extend(bbc_list)))
+        await ngin.send(compose_events_message(fta_list + bbc_list))
 
 
 if __name__ == '__main__':

--- a/services/hermes/commands.py
+++ b/services/hermes/commands.py
@@ -72,7 +72,7 @@ async def send_guide(ctx: Context):
                 await ctx.send(bbc_message)
     finally:
         await ctx.send(reminders_message)
-        await ngin.send(compose_events_message(fta_list.extend(bbc_list)))
+        await ngin.send(compose_events_message(fta_list + bbc_list))
 
 @hermes.command()
 async def send_guide_record(ctx: Context, date_to_send: str):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -20,7 +20,7 @@ class TestDatabase(unittest.TestCase):
     def setUpClass(self) -> None:
         super().setUpClass()
         load_dotenv('.env')
-        os.environ['ENV'] = 'testing'
+        os.environ['PYTHON_ENV'] = 'testing'
         self.database_service = DatabaseService(mongo_client().get_database('test'))
 
         with open('tests/test_data/recorded_shows.json') as fd:


### PR DESCRIPTION
### Ticket
[TVG-27](https://natalie-g-projects.atlassian.net/browse/TVG-27)

### Description
The function that composes the events message was recently changed to receive the list of GuideShows and use the event attribute from the object. The `extend()` function had been used, however since this returns None, `compose_events_message()` was throwing an error in regards to using a NoneType as an iterable.

This PR adds the two lists instead of calling extend on the FTA list. It also makes sure the events are sent when using the local guide.

### ENV variable changes
None

[TVG-27]: https://natalie-g-projects.atlassian.net/browse/TVG-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ