### PR TITLE
[TVG-29] Episodes not updated

### DIFF
--- a/dev-data/fta_source_data.json
+++ b/dev-data/fta_source_data.json
@@ -29,7 +29,7 @@
                 "repeat": true,
                 "description": "A hit and run and a stabbing death in a remote Northumberland valley have DCI Vera Stanhope and her team investigating the connection between the two people involved.",
                 "series-crid": "ZW0937A",
-                "start_time": "2024-01-12T13:00:00",
+                "start_time": "2024-01-13T13:00:00",
                 "genres": [
                     "Drama"
                 ],
@@ -42,7 +42,33 @@
                 "series_num": 6,
                 "episode_title": "The Moth Catcher",
                 "length": 90,
-                "end_time": "2024-01-11T14:30:00"
+                "end_time": "2024-01-13T14:30:00"
+            },
+            {
+                "title": "Vera",
+                "start_time": "2024-01-13T17:00:00",
+                "episode_title": "Unknown Test"
+            },
+            {
+                "title": "Vera",
+                "start_time": "2024-01-13T18:30:00",
+                "series_num": "15",
+                "episode_num": "1",
+                "episode_title": "Both season number and episode number as string"
+            },
+            {
+                "title": "Vera",
+                "start_time": "2024-01-13T20:00:00",
+                "series_num": 15,
+                "episode_num": "1",
+                "episode_title": "Season number as integer and episode number as string"
+            },
+            {
+                "title": "Vera",
+                "start_time": "2024-01-13T21:30:00",
+                "series_num": "15",
+                "episode_num": 1,
+                "episode_title": "Season number as string and episode number as integer"
             }
         ]
     },

--- a/dev-data/fta_source_data.json
+++ b/dev-data/fta_source_data.json
@@ -14,6 +14,35 @@
                 "series_num": "5",
                 "episode_num": "1",
                 "episode_title": "Muse"
+            },
+            {
+                "captioning": true,
+                "rating": "M",
+                "crid": "ZW0937A003S00",
+                "episode_num": 3,
+                "show_id": 513103,
+                "title": "Vera",
+                "live": false,
+                "image_file": "ZW0937A003S00_460.jpg",
+                "prog_slug": "vera",
+                "consumer_advice": "Adult Themes, Violence",
+                "repeat": true,
+                "description": "A hit and run and a stabbing death in a remote Northumberland valley have DCI Vera Stanhope and her team investigating the connection between the two people involved.",
+                "series-crid": "ZW0937A",
+                "start_time": "2024-01-12T13:00:00",
+                "genres": [
+                    "Drama"
+                ],
+                "show_type": "Episode",
+                "access_service": {
+                    "access_service_ref": "Audio Described",
+                    "access_service_language": "English [ENG]"
+                },
+                "onair_title": "Vera",
+                "series_num": 6,
+                "episode_title": "The Moth Catcher",
+                "length": 90,
+                "end_time": "2024-01-11T14:30:00"
             }
         ]
     },

--- a/dev-data/search_list.json
+++ b/dev-data/search_list.json
@@ -30,5 +30,13 @@
 
         },
         "search_active": true
+    },
+    {
+        "show": "Vera",
+        "image": "",
+        "conditions": {
+
+        },
+        "search_active": true
     }
 ]

--- a/guide.py
+++ b/guide.py
@@ -46,7 +46,7 @@ def search_free_to_air(database_service: DatabaseService):
                         episode_number = 0
                         episode_title = ''
                         if 'series_num' in guide_show.keys() and 'episode_num' in guide_show.keys():
-                            season_number = str(guide_show['series_num'])
+                            season_number = int(guide_show['series_num'])
                             episode_number = int(guide_show['episode_num'])
                         if 'episode_title' in guide_show.keys():
                             episode_title = guide_show['episode_title']

--- a/local_guide.py
+++ b/local_guide.py
@@ -30,12 +30,12 @@ async def send_main_message():
         await ngin.send('The channel resolved to NoneType so the message could not be sent')
     finally:
         await tvguide_channel.send(reminder_message)
-        await ngin.send(events_message)
+        await tvguide_channel.send(events_message)
     
     await hermes.close()
 
 def local_message():
-    guide_message, reminder_message = get_guide_data()
+    guide_message, reminder_message, events_message = get_guide_data()
 
     print(guide_message)
     print(reminder_message)

--- a/services/hermes/events.py
+++ b/services/hermes/events.py
@@ -15,6 +15,12 @@ async def on_show_not_processed(show: str, err: Exception):
     await send_message(message)
 
 @hermes.event
+async def on_episode_not_updated(show: str, season_number: int, episode_number: int = 0, episode_title: str = ''):
+    episode = episode_title if not episode_number else f'{episode_number}, {episode_title}'
+    message = f'Season {season_number}, Episode {episode} of {show} was not updated'
+    await send_message(message)    
+
+@hermes.event
 async def on_db_not_connected(err: str):
     message = f'Having trouble connecting to the database.\nError: {err}'
-    await  send_message(message)
+    await send_message(message)

--- a/services/hermes/utilities.py
+++ b/services/hermes/utilities.py
@@ -5,6 +5,7 @@ from services.hermes.hermes import hermes
 
 async def send_message(message: str):
     tvguide_channel: TextChannel = hermes.get_channel(int(os.getenv('TVGUIDE_CHANNEL')))
+    await hermes.wait_until_ready()
     if tvguide_channel is not None:
         await tvguide_channel.send(message)
     else:

--- a/tests/test_guide.py
+++ b/tests/test_guide.py
@@ -46,7 +46,7 @@ class TestGuide(unittest.TestCase):
         data = search_free_to_air(self.database_service)
         
         guide_show_all_details = data[0]
-        self.assertEqual('4', guide_show_all_details.season_number)
+        self.assertEqual(4, guide_show_all_details.season_number)
         self.assertEqual(4, guide_show_all_details.episode_number)
         self.assertEqual('The Sontaran Strategem', guide_show_all_details.episode_title)
 
@@ -59,7 +59,7 @@ class TestGuide(unittest.TestCase):
         data = search_free_to_air(self.database_service)
         
         guide_show_episode_num = data[1]
-        self.assertEqual('4', guide_show_episode_num.season_number)
+        self.assertEqual(4, guide_show_episode_num.season_number)
         self.assertEqual(5, guide_show_episode_num.episode_number)
         self.assertEqual('', guide_show_episode_num.episode_title)
 


### PR DESCRIPTION
### Ticket
[TVG-29](https://natalie-g-projects.atlassian.net/browse/TVG-29)

### Description
Some episodes were not being updated in the database. This was found to be caused by casting the season number to a string when the information was being collected from FTA shows. As a result, MongoDB was not able to modify the episode, even though it was able to match it. Casting the season number to an integer is able to resolve the issue.

A Discord event has been also added so that in cases where an episode is not updated, Discord will send a message.

### ENV variable changes
None

[TVG-29]: https://natalie-g-projects.atlassian.net/browse/TVG-29?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ