### PR TITLE
[TVG-28] Unable to remove all subscriptions

### DIFF
--- a/api.py
+++ b/api.py
@@ -180,7 +180,7 @@ def get_user(username: str):
         return user_data
     return {'message': f'An account with the username {username} could not be found'}, 404
 
-@app.route('/api/user/<string:username>/subscriptions', methods=['PUT'])
+@app.route('/api/users/<string:username>/subscriptions', methods=['PUT'])
 @jwt_required()
 def edit_user_subscriptions(username: str):
     user = database_service.get_user(username)
@@ -192,8 +192,9 @@ def edit_user_subscriptions(username: str):
         try:
             user_was_updated = database_service.update_user_subscriptions(
                 username,
-                body['show_subscriptions'] if 'show_subscriptions' in body.keys() else None,
-                body['reminder_subscriptions'] if 'reminder_subscriptions' in body.keys() else None
+                body['operation'],
+                body['resource'],
+                body['subscriptions']
             )
             if user_was_updated:
                 return {'message': 'Your subscriptions were updated', 'user': user_was_updated}

--- a/api.py
+++ b/api.py
@@ -1,6 +1,7 @@
 from flask import Flask, request
 from flask_cors import CORS
 from flask_jwt_extended import create_access_token, JWTManager, jwt_required, get_current_user
+import sys
 import os
 
 from config import database_service
@@ -275,5 +276,8 @@ def events():
     return events
 
 if __name__ == '__main__':
-    os.environ['PYTHON_ENV'] = 'production'
+    if len(sys.argv) > 1:
+        os.environ['PYTHON_ENV'] = sys.argv[1]
+    else:
+        os.environ['PYTHON_ENV'] = 'production'        
     app.run(host='0.0.0.0', port='5000', debug=True)

--- a/database/DatabaseService.py
+++ b/database/DatabaseService.py
@@ -433,6 +433,7 @@ class DatabaseService:
         self.source_data_collection.delete_many({})
         self.search_list_collection.delete_many({})
         self.recorded_shows_collection.delete_many({})
+        self.users_collection.delete_many({})
 
         with open('dev-data/search_list.json') as fd:
             search_list = json.load(fd)
@@ -447,6 +448,14 @@ class DatabaseService:
             bbc_uktv_data = list(json.load(fd))
         with open('dev-data/recorded_shows.json') as fd:
             recorded_shows = list(json.load(fd))
+        with open('dev-data/users.json') as fd:
+            raw_users = list(json.load(fd))
+            users = [User.register_new_user(
+                user['username'],
+                user['password'],
+                user['show_subscriptions'],
+                user['reminder_subscriptions']
+            ) for user in raw_users]
         
         fta_result = self.source_data_collection.insert_one({
             'service': "FTA",
@@ -465,6 +474,9 @@ class DatabaseService:
         print(bbc_uktv_result.inserted_id, 'added to SourceData collection')
 
         self.recorded_shows_collection.insert_many(recorded_shows)
+        
+        users_result = self.users_collection.insert_many([user.to_dict() for user in users])
+        print(users_result.inserted_ids, 'added to the Users collection')
 
     def tear_down_data(self):
         self.source_data_collection.delete_many({})

--- a/dev-data/users.json
+++ b/dev-data/users.json
@@ -1,0 +1,15 @@
+[
+    {
+        "username": "Natalie",
+        "password": "test",
+        "show_subscriptions": [
+            "Doctor Who",
+            "Endeavour",
+            "Maigret"
+        ],
+        "reminder_subscriptions": [
+
+        ],
+        "role": "Standard"
+    }
+]

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -354,31 +354,31 @@ class TestDatabase(unittest.TestCase):
     def test_add_show_subscriptions(self):
         intial_user = self.database_service.get_user('Splintax')
 
-        self.database_service.update_user_subscriptions('Splintax', ['Maigret', 'Vera', 'Transformers: Prime', 'Shetland'])
+        self.database_service.update_user_subscriptions('Splintax', 'add', 'searchList', ['Maigret', 'Vera', 'Transformers: Prime', 'Shetland'])
 
         post_user = self.database_service.get_user('Splintax')
 
         self.assertEqual(2, len(intial_user.show_subscriptions))
-        self.assertEqual(4, len(post_user.show_subscriptions))
+        self.assertEqual(6, len(post_user.show_subscriptions))
         self.assertIn('Transformers: Prime', post_user.show_subscriptions)
         self.assertIn('Shetland', post_user.show_subscriptions)
         
     def test_remove_show_subscriptions(self):
         intial_user = self.database_service.get_user('Crux')
 
-        self.database_service.update_user_subscriptions('Crux', ['Transformers: Prime'])
+        self.database_service.update_user_subscriptions('Crux', 'remove', 'searchList', ['Transformers: Prime'])
 
         post_user = self.database_service.get_user('Crux')
 
         self.assertEqual(2, len(intial_user.show_subscriptions))
         self.assertEqual(1, len(post_user.show_subscriptions))
-        self.assertIn('Transformers: Prime', post_user.show_subscriptions)
-        self.assertNotIn('Transformers: Cyberverse', post_user.show_subscriptions)
+        self.assertNotIn('Transformers: Prime', post_user.show_subscriptions)
+        self.assertIn('Transformers: Cyberverse', post_user.show_subscriptions)
 
     def test_add_reminder_subscriptions(self):
         intial_user = self.database_service.get_user('Sulejmani')
 
-        self.database_service.update_user_subscriptions('Sulejmani', reminder_subscriptions=['Transformers: Prime'])
+        self.database_service.update_user_subscriptions('Sulejmani', 'add', 'reminders', ['Transformers: Prime'])
 
         post_user = self.database_service.get_user('Sulejmani')
 
@@ -389,20 +389,20 @@ class TestDatabase(unittest.TestCase):
     def test_remove_reminder_subscriptions(self):
         intial_user = self.database_service.get_user('Jazz')
 
-        self.database_service.update_user_subscriptions('Jazz', reminder_subscriptions=['Doctor Who'])
+        self.database_service.update_user_subscriptions('Jazz', 'remove', 'reminders', ['Doctor Who'])
 
         post_user = self.database_service.get_user('Jazz')
 
         self.assertEqual(3, len(intial_user.reminder_subscriptions))
-        self.assertEqual(1, len(post_user.reminder_subscriptions))
-        self.assertIn('Doctor Who', post_user.reminder_subscriptions)
-        self.assertNotIn('Endeavour', post_user.reminder_subscriptions)
-        self.assertNotIn('Shetland', post_user.reminder_subscriptions)
+        self.assertEqual(2, len(post_user.reminder_subscriptions))
+        self.assertNotIn('Doctor Who', post_user.reminder_subscriptions)
+        self.assertIn('Endeavour', post_user.reminder_subscriptions)
+        self.assertIn('Shetland', post_user.reminder_subscriptions)
 
     def test_updating_subscriptions_raises_error(self):
         with self.assertRaises(InvalidSubscriptions) as context:
-            self.database_service.update_user_subscriptions('Crux')
-        self.assertIn('updated list of subscriptions', str(context.exception))
+            self.database_service.update_user_subscriptions('Crux', 'add', 'searchList', [])
+        self.assertIn('Please provide a list of show subscriptions', str(context.exception))
 
     def test_promote_user_succeeds(self):
         user_initial = self.database_service.get_user('Splintax')


### PR DESCRIPTION
### Ticket
[TVG-28](https://natalie-g-projects.atlassian.net/browse/TVG-28)

### Description
The current implementation for removing subscriptions receives the updated list as part of the request. If the length of the subscriptions to remove is 0, an error is thrown. This error being thrown is preventing all subscriptions from being removed.

This PR reworks the implementation for more explicit handling. The request now has a payload consisting of:

- operation (adding or removing a subscription)
- resource (show list or reminders)
- subscriptions (the list of subscriptions to add or remove)

The DatabaseService now handles the process using the above data

### ENV variable changes
None

[TVG-28]: https://natalie-g-projects.atlassian.net/browse/TVG-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ