### PR TITLE
[TVG-16] Duplicate DB Events

### DIFF
--- a/database/DatabaseService.py
+++ b/database/DatabaseService.py
@@ -433,21 +433,20 @@ class DatabaseService:
         return dict(source_data)
     
     def import_data(self, resource: str):
-        print(resource)
-        # match resource:
-        #     case 'recorded_shows':
-        #         self.import_recorded_shows()
-        #     case 'source_data':
-        #         self.import_source_data()
-        #     case 'search_list':
-        #         self.import_search_list()
-        #     case 'users':
-        #         self.import_users()
-        #     case 'all':
-        #         self.import_recorded_shows()
-        #         self.import_source_data()
-        #         self.import_search_list()
-        #         self.import_users()
+        match resource:
+            case 'recorded_shows':
+                self.import_recorded_shows()
+            case 'source_data':
+                self.import_source_data()
+            case 'search_list':
+                self.import_search_list()
+            case 'users':
+                self.import_users()
+            case 'all':
+                self.import_recorded_shows()
+                self.import_source_data()
+                self.import_search_list()
+                self.import_users()
 
     def import_recorded_shows(self):
         self.recorded_shows_collection.delete_many({})

--- a/database/models/GuideShow.py
+++ b/database/models/GuideShow.py
@@ -61,8 +61,7 @@ class GuideShow:
             new_show = True
             episode_number = unknown_episodes
         elif episode_title == "":
-            unknown_season_episodes = recorded_show.get_unknown_episodes_count()
-            episode_number = 1 if unknown_episodes + unknown_season_episodes == 0 else unknown_episodes + unknown_season_episodes
+            episode_number = 1 if unknown_episodes == 0 else unknown_episodes
         else:
             episode_search = recorded_show.find_episode_instances(episode_title)
             if episode_search is None:

--- a/dev-data/bbc_first_source_data.json
+++ b/dev-data/bbc_first_source_data.json
@@ -6,9 +6,9 @@
         "start": "2023-12-26 18:30:00",
         "episode": {
             "series": {
-                "number": "18"
+                "number": 18
             },
-            "number": "7",
+            "number": 7,
             "title": "Squaring the Circle: Part 1"
         }
     },

--- a/dev-data/bbc_uktv_source_data.json
+++ b/dev-data/bbc_uktv_source_data.json
@@ -6,10 +6,49 @@
         "start": "2023-12-26 12:30:00",
         "episode": {
             "series": {
-                "number": "2"
+                "number": 2
             },
-            "number": "3",
+            "number": 3,
             "title": "Life Born of Fire"
+        }
+    },
+    {
+        "show": {
+            "title": "Professor T"
+        },
+        "start": "2023-12-26 14:00:00",
+        "episode": {
+            "series": {
+                "number": 1
+            },
+            "number": 1,
+            "title": "Anatomy of a Memory"
+        }
+    },
+    {
+        "show": {
+            "title": "Professor T"
+        },
+        "start": "2023-12-26 15:00:00",
+        "episode": {
+            "series": {
+                "number": 2
+            },
+            "number": 1,
+            "title": "Ring of Fire"
+        }
+    },
+    {
+        "show": {
+            "title": "Professor T"
+        },
+        "start": "2023-12-26 16:00:00",
+        "episode": {
+            "series": {
+                "number": 2
+            },
+            "number": 2,
+            "title": "The Mask Murders"
         }
     }
 ]

--- a/dev-data/fta_source_data.json
+++ b/dev-data/fta_source_data.json
@@ -69,6 +69,27 @@
                 "series_num": "15",
                 "episode_num": 1,
                 "episode_title": "Season number as string and episode number as integer"
+            },
+            {
+                "title": "Doctor Who",
+                "start_time": "2024-03-09T20:30:00",
+                "series_num": 14,
+                "episode_num": 1,
+                "episode_title": "The Star Beast"
+            },
+            {
+                "title": "Doctor Who",
+                "start_time": "2024-03-09T21:30:00",
+                "series_num": 14,
+                "episode_num": 2,
+                "episode_title": "Wild Blue Yonder"
+            },
+            {
+                "title": "Doctor Who",
+                "start_time": "2024-03-09T22:30:00",
+                "series_num": 14,
+                "episode_num": 3,
+                "episode_title": "The Giggle"
             }
         ]
     },
@@ -134,6 +155,20 @@
                 "genres": [
                     "Animation"
                 ]
+            },
+            {
+                "title": "Transformers: Prime",
+                "start_time": "2024-03-09T13:00:00",
+                "series_num": 1,
+                "episode_num": 1,
+                "episode_title": "Darkness Rising - Part 1"
+            },
+            {
+                "title": "Transformers: Prime",
+                "start_time": "2024-03-09T13:30:00",
+                "series_num": 1,
+                "episode_num": 2,
+                "episode_title": "Darkness Rising - Part 2"
             }
         ]
     }

--- a/dev-data/search_list.json
+++ b/dev-data/search_list.json
@@ -54,5 +54,21 @@
 
         },
         "search_active": true
+    },
+    {
+        "show": "Doctor Who",
+        "image": "",
+        "conditions": {
+
+        },
+        "search_active": true
+    },
+    {
+        "show": "Professor T",
+        "image": "",
+        "conditions": {
+
+        },
+        "search_active": true
     }
 ]

--- a/guide.py
+++ b/guide.py
@@ -61,8 +61,14 @@ def search_free_to_air(database_service: DatabaseService):
                         shows_data.extend(episodes)
 
     shows_data = Validation.remove_unwanted_shows(shows_data)
+    shows_data.sort(key=lambda show: (show['time'], show['channel']))
 
-    shows_on = build_guide_shows(shows_data, database_service)
+    shows_on: list['GuideShow'] = []
+    for show in shows_data:
+        guide_show = build_guide_show(show, database_service, shows_data)
+        if 'HD' not in guide_show.channel:
+            database_service.capture_db_event(guide_show)
+        shows_on.append(guide_show)
     
     return shows_on
 
@@ -108,41 +114,41 @@ def search_bbc_australia(database_service: DatabaseService):
     search_channel_data(bbc_uktv_data, 'BBC UKTV')
 
     show_list = Validation.remove_unwanted_shows(show_list)
-    shows_on = build_guide_shows(show_list, database_service)
-
-    return shows_on
-
-def build_guide_shows(show_list: list[dict], database_service: DatabaseService):
-    shows_on: list[GuideShow] = []
+    show_list.sort(key=lambda show_obj: (show_obj['time'], show_obj['channel']))
+    
+    shows_on: list['GuideShow'] = []
     for show in show_list:
-        episode_data = GuideShow.get_show(show['title'], show['season_number'], show['episode_number'], show['episode_title'])
-        title, season_number, episode_number, episode_title = episode_data
-        recorded_show = database_service.get_one_recorded_show(title)
-
-        if season_number != 'Unknown':
-            guide_show = GuideShow.known_season(
-                title,
-                (show['channel'], show['time']),
-                (season_number, episode_number, episode_title),
-                recorded_show
-            )
-        else:
-            episode_number = Validation.get_unknown_episode_number(show_list, title, episode_title)
-            if episode_number is None:
-                episode_number = 0
-            guide_show = GuideShow.unknown_season(
-                title,
-                (show['channel'], show['time']),
-                episode_title,
-                recorded_show,
-                episode_number
-            )
+        guide_show = build_guide_show(show, database_service, show_list)
+        database_service.capture_db_event(guide_show)
         shows_on.append(guide_show)
 
-    shows_on = list(set(shows_on))
-    shows_on.sort(key=lambda show_obj: (show_obj.time, show_obj.channel))
-    
     return shows_on
+
+def build_guide_show(show: dict, database_service: DatabaseService, show_list: list[dict]):
+    episode_data = GuideShow.get_show(show['title'], show['season_number'], show['episode_number'], show['episode_title'])
+    title, season_number, episode_number, episode_title = episode_data
+    recorded_show = database_service.get_one_recorded_show(title)
+
+    if season_number != 'Unknown':
+        guide_show = GuideShow.known_season(
+            title,
+            (show['channel'], show['time']),
+            (season_number, episode_number, episode_title),
+            recorded_show
+        )
+    else:
+        episode_number = Validation.get_unknown_episode_number(show_list, title, episode_title)
+        if episode_number is None:
+            episode_number = 0
+        guide_show = GuideShow.unknown_season(
+            title,
+            (show['channel'], show['time']),
+            episode_title,
+            recorded_show,
+            episode_number
+        )
+
+    return guide_show
 
 def compose_message(fta_shows: list['GuideShow'], bbc_shows: list['GuideShow'], date_provided: datetime = None):
     """
@@ -208,9 +214,6 @@ def run_guide(database_service: DatabaseService, fta_list: list['GuideShow'], bb
     if update_db_flag:
         database_service.backup_recorded_shows()
         
-        for guide_show in guide_list:
-            if 'HD' not in guide_show.channel:
-                database_service.capture_db_event(guide_show)
         database_service.add_guide_data(fta_list, bbc_list)
 
     reminders_message = reminders(guide_list, database_service, scheduler)

--- a/tests/test_data/search_list.json
+++ b/tests/test_data/search_list.json
@@ -1,0 +1,62 @@
+[
+    {
+        "show": "NCIS",
+        "image": "https://image_url.com",
+        "conditions": {
+            "exclude_titles": [
+                "NCIS: New Orleans",
+                "NCIS: Hawaii"
+            ]
+        },
+        "search_active": true
+    },
+    {
+        "show": "Maigret",
+        "image": "https://image_url.com",
+        "conditions": {
+        
+        },
+        "search_active": false
+    },
+    {
+        "show": "Lewis",
+        "image": "https://image_url.com",
+        "conditions": {
+            "exact_search": true
+        },
+        "search_active": true
+    },
+    {
+        "show": "Death in Paradise",
+        "image": "https://image_url.com",
+        "conditions": {
+            "min_season": 3
+        },
+        "search_active": true
+    },
+    {
+        "show": "Doctor Who",
+        "image": "https://image_url.com",
+        "conditions": {
+            "max_season": 10
+        },
+        "search_active": true
+    },
+    {
+        "show": "Vera",
+        "image": "https://image_url.com",
+        "conditions": {
+            "min_season": 1,
+            "max_season": 4
+        },
+        "search_active": true
+    },
+    {
+        "show": "Transformers",
+        "image": "https://image_url.com",
+        "conditions": {
+            "only_season": 2
+        },
+        "search_active": true
+    }
+]

--- a/tests/test_guide.py
+++ b/tests/test_guide.py
@@ -26,6 +26,10 @@ class TestGuide(unittest.TestCase):
             new_reminder = Reminder.from_database(reminder)
             self.database_service.insert_new_reminder(new_reminder)
 
+        with open('tests/test_data/search_list.json') as fd:
+            search_list = json.load(fd)
+        self.database_service.search_list_collection.insert_many(search_list)
+
     def guide_data():
         with open('tests/test_data/fta_data.json') as fd:
             fta_data = json.load(fd)
@@ -168,6 +172,9 @@ class TestGuide(unittest.TestCase):
         reminders = self.database_service.get_all_reminders()
         for reminder in reminders:
             self.database_service.delete_reminder(reminder.show)
+
+        self.database_service.search_list_collection.delete_many({})
+        self.database_service.recorded_shows_collection.delete_many({})
 
 
 if __name__ == '__main__':

--- a/tests/test_guide_show.py
+++ b/tests/test_guide_show.py
@@ -85,7 +85,7 @@ class TestGuideShow(unittest.TestCase):
             dw_recorded_show,
             2
         )
-        self.assertEqual(5, unknown_episode.episode_number)
+        self.assertEqual(2, unknown_episode.episode_number)
         self.assertEqual('Unknown', unknown_episode.season_number)
 
     def test_season_unknown_finds_recorded_episode_repeat_true(self):


### PR DESCRIPTION
### Ticket
[TVG-16](https://natalie-g-projects.atlassian.net/browse/TVG-16)

### Description
Some episodes would contain the same database event. For example, Silent Witness Season 18 Episode 1 and Season 18 Episode 2 would both try to add the Season to the RecordedShow if Season 18 did not exist.
This is because updating the RecordedShow occurs after all DB events had been captured, and Episode 2 would not know that Season 18 was going to be added.
This PR ensures that the DB event occurs as the GuideShow is built.

### ENV variable changes
None

[TVG-16]: https://natalie-g-projects.atlassian.net/browse/TVG-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ