### PR TITLE
[TVG-33] BBC Reminders Error

### DIFF
--- a/database/DatabaseService.py
+++ b/database/DatabaseService.py
@@ -433,21 +433,20 @@ class DatabaseService:
         return dict(source_data)
     
     def import_data(self, resource: str):
-        print(resource)
-        # match resource:
-        #     case 'recorded_shows':
-        #         self.import_recorded_shows()
-        #     case 'source_data':
-        #         self.import_source_data()
-        #     case 'search_list':
-        #         self.import_search_list()
-        #     case 'users':
-        #         self.import_users()
-        #     case 'all':
-        #         self.import_recorded_shows()
-        #         self.import_source_data()
-        #         self.import_search_list()
-        #         self.import_users()
+        match resource:
+            case 'recorded_shows':
+                self.import_recorded_shows()
+            case 'source_data':
+                self.import_source_data()
+            case 'search_list':
+                self.import_search_list()
+            case 'users':
+                self.import_users()
+            case 'all':
+                self.import_recorded_shows()
+                self.import_source_data()
+                self.import_search_list()
+                self.import_users()
 
     def import_recorded_shows(self):
         self.recorded_shows_collection.delete_many({})

--- a/database/models/Reminders.py
+++ b/database/models/Reminders.py
@@ -51,7 +51,7 @@ class Reminder:
     def calculate_notification_time(self):
         if self.reminder_alert == 'On-Start':
             self.notify_time = self.airing_details[1]
-        elif self.reminder_alert == 'After':            
+        elif self.reminder_alert == 'After':
             self.notify_time = self.airing_details[1] + timedelta(minutes=self.warning_time)
         else:
             self.notify_time = self.airing_details[1] - timedelta(minutes=self.warning_time)

--- a/guide.py
+++ b/guide.py
@@ -97,7 +97,7 @@ def search_bbc_australia(database_service: DatabaseService):
                     episodes = build_episode(
                         title,
                         channel,
-                        start_time.time(),
+                        start_time,
                         series_num,
                         episode_num,
                         episode_title

--- a/tests/test_data/search_list.json
+++ b/tests/test_data/search_list.json
@@ -1,0 +1,62 @@
+[
+    {
+        "show": "NCIS",
+        "image": "https://image_url.com",
+        "conditions": {
+            "exclude_titles": [
+                "NCIS: New Orleans",
+                "NCIS: Hawaii"
+            ]
+        },
+        "search_active": true
+    },
+    {
+        "show": "Maigret",
+        "image": "https://image_url.com",
+        "conditions": {
+        
+        },
+        "search_active": false
+    },
+    {
+        "show": "Lewis",
+        "image": "https://image_url.com",
+        "conditions": {
+            "exact_search": true
+        },
+        "search_active": true
+    },
+    {
+        "show": "Death in Paradise",
+        "image": "https://image_url.com",
+        "conditions": {
+            "min_season": 3
+        },
+        "search_active": true
+    },
+    {
+        "show": "Doctor Who",
+        "image": "https://image_url.com",
+        "conditions": {
+            "max_season": 10
+        },
+        "search_active": true
+    },
+    {
+        "show": "Vera",
+        "image": "https://image_url.com",
+        "conditions": {
+            "min_season": 1,
+            "max_season": 4
+        },
+        "search_active": true
+    },
+    {
+        "show": "Transformers",
+        "image": "https://image_url.com",
+        "conditions": {
+            "only_season": 2
+        },
+        "search_active": true
+    }
+]

--- a/tests/test_guide.py
+++ b/tests/test_guide.py
@@ -26,6 +26,10 @@ class TestGuide(unittest.TestCase):
             new_reminder = Reminder.from_database(reminder)
             self.database_service.insert_new_reminder(new_reminder)
 
+        with open('tests/test_data/search_list.json') as fd:
+            search_list = json.load(fd)
+        self.database_service.search_list_collection.insert_many(search_list)
+
     def guide_data():
         with open('tests/test_data/fta_data.json') as fd:
             fta_data = json.load(fd)
@@ -168,6 +172,9 @@ class TestGuide(unittest.TestCase):
         reminders = self.database_service.get_all_reminders()
         for reminder in reminders:
             self.database_service.delete_reminder(reminder.show)
+
+        self.database_service.search_list_collection.delete_many({})
+        self.database_service.recorded_shows_collection.delete_many({})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Ticket
[TVG-33](https://natalie-g-projects.atlassian.net/browse/TVG-33)

### Description
An error would be thrown when creating reminders for BBC episodes. Python's timedelta expects a datetime object and the time attribute for BBC GuideShows were being set to a time object.
This PR changes passes the full datetime object to the GuideShow constructor rather than the time object.
This has also not occurred yet in production since BBC source data is empty.

### ENV variable changes
None

[TVG-33]: https://natalie-g-projects.atlassian.net/browse/TVG-33?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ