### PR TITLE
[TVG-36] SBS Episode Handling

### DIFF
--- a/aux_methods/helper_methods.py
+++ b/aux_methods/helper_methods.py
@@ -175,6 +175,10 @@ def build_episode(show_title: str, channel: str, time: datetime, season_number: 
                 'episode_title': Validation.format_episode_title(episode.title())
             })
     else:
+        if 'SBS' in channel:
+            sbs_format = sbs_episode_format(show_title, episode_title)
+            if isinstance(sbs_format, tuple):
+                season_number, episode_number = sbs_format
         episodes.append({
             'title': show_title,
             'channel': channel,
@@ -198,3 +202,11 @@ def split_message_by_time(message: str):
     pm_message = message[am_index:]
 
     return am_message, pm_message
+
+def sbs_episode_format(show_title: str, episode: str):
+    search = re.match(rf"{show_title} Series \d+ Ep \d+", episode)
+    if search:
+        numbers = tuple(int(number) for number in re.findall(r"\d+", episode))
+        return numbers
+    else:
+        return episode

--- a/dev-data/fta_source_data.json
+++ b/dev-data/fta_source_data.json
@@ -143,6 +143,31 @@
         ]
     },
     {
+        "channel": "SBS",
+        "listing": [
+            {
+                "consumer_advice": "",
+                "rating": "CTC",
+                "show_id": 1058295,
+                "repeat": false,
+                "description": "The day after Litvinenko's death, radiation teams swarm across London to secure potentially contaminated sites visited by the Russian spy. Officers discover traces of Polonium at Itsu, a sushi restaurant where Litvinenko met Mario Scaramella before a later encounter with Andrey Lugovoy and Dmitry Kovtun at the Millennium Hotel, which has also tested positive for Polonium.",
+                "title": "Litvinenko",
+                "crid": "crid://sydney.sbsone.sbs.au/1239832",
+                "start_time": "2024-04-05T21:30:00",
+                "series-crid": "crid://sbs.com.au/239907",
+                "live": false,
+                "captioning": true,
+                "show_type": "Episode",
+                "episode_title": "Litvinenko Series 1 Ep 2",
+                "length": 55,
+                "end_time": "2024-04-03T22:25:00",
+                "genres": [
+                    "Drama"
+                ]
+            }
+        ]
+    },
+    {
         "channel": "7TWO",
         "listing": [
             {

--- a/dev-data/search_list.json
+++ b/dev-data/search_list.json
@@ -91,5 +91,14 @@
 
         },
         "search_active": true
+    },
+    {
+        "show": "Litvinenko",
+        "image": "",
+        "conditions": {
+
+        },
+        "search_active": true
     }
+    
 ]

--- a/tests/test_data/validation_test_data.json
+++ b/tests/test_data/validation_test_data.json
@@ -134,5 +134,13 @@
         "season_number": "Unknown",
         "episode_number": 0,
         "episode_title": ""
+    },
+    {
+        "title": "Litvinenko",
+        "channel": "SBS",
+        "time": "20:30",
+        "season_number": "Unknown",
+        "episode_number": 0,
+        "episode_title": "Litvinenko Series 1 Ep 1"
     }
 ]

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import unittest
 import json
 
+from aux_methods.helper_methods import sbs_episode_format
 from database.models.GuideShow import GuideShow
 from database.models.RecordedShow import RecordedShow
 from data_validation.validation import Validation
@@ -100,3 +101,17 @@ class TestValidation(unittest.TestCase):
         self.assertEqual(4, shows_on[0].episode_number)
         self.assertEqual(5, shows_on[1].episode_number)
         self.assertEqual(6, shows_on[2].episode_number)
+
+    def test_sbs_episode_format_returns_season_episode_number(self):
+        sbs_data = next((show for show in self.data if show['title'] == 'Litvinenko'), None)
+        season_number, episode_number = sbs_episode_format(sbs_data['title'], sbs_data['episode_title'])
+        
+        self.assertEqual(season_number, 1)
+        self.assertEqual(episode_number, 1)
+
+    def test_sbs_episode_format_fails(self):
+        sbs_data = next((show for show in self.data if show['title'] == 'Litvinenko'), None)
+        sbs_data['episode_title'] = 'Series 1 Ep 1'
+        result = sbs_episode_format(sbs_data['title'], sbs_data['episode_title'])
+        
+        self.assertEqual(result, 'Series 1 Ep 1')


### PR DESCRIPTION
### Ticket
[TVG-36](https://natalie-g-projects.atlassian.net/browse/TVG-36)

### Description
SBS shows do not provide any season or episode information separately, instead adding them into the episode title.
This PR provides some handling to extract the season and episode numbers from the episode title provided.

### ENV variable changes
None

[TVG-36]: https://natalie-g-projects.atlassian.net/browse/TVG-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ