### PR TITLE
[TVG-38] Fix Recording of TVMaze seasons

### DIFF
--- a/services/tvmaze/tvmaze_api.py
+++ b/services/tvmaze/tvmaze_api.py
@@ -27,6 +27,9 @@ def get_show_data(show: str, tvmaze_id: str, season_start: int = 0, include_spec
             }
             episode_list.append(episode)
 
+    if api_data[0]['season'] != 1 and season_start == 0:
+        season_start = api_data[0]['season'] - 1
+
     show_details['seasons'] = group_seasons(episode_list, api_data[-1]['season'], season_start)
     return show_details
 

--- a/services/tvmaze/tvmaze_helpers.py
+++ b/services/tvmaze/tvmaze_helpers.py
@@ -1,6 +1,5 @@
 def format_episode_title(episode_title: str):
     if '(Part ' in episode_title:
-        # print('running')
         episode_title = episode_title.replace('(Part ', 'Part ')
         episode_title = episode_title.replace(')', '')
     if 'Part I' in episode_title and 'Part II' not in episode_title:


### PR DESCRIPTION
### Ticket
[TVG-38](https://natalie-g-projects.atlassian.net/browse/TVG-38)

### Description
For some shows on TVMaze, a show's first season number may not be 1. If this was this case, as it was with Maigret, all seasons from 1 until the last season would be created. Continuing with Maigret as the example, the first season is regared as 2016 (since the show started in 2016) and the last as 2017. Therefore, the newly created RecordedShow document would contain 2017 season sub-documents, with the first 2015 being empty.

This PR ensures that if a show on TVMaze does not start a season with 1, the first season number would be used instead.

### ENV variable changes
None

[TVG-38]: https://natalie-g-projects.atlassian.net/browse/TVG-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ