### PR TITLE
[TVG-34] Scheduler Jobstore Fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ on:
 env:
   TVGUIDE_DB: ${{ secrets.TVGUIDE_DB }}
   PYTHON_ENV: testing
+  DATABASE_NAME: ${{ secrets.DATABASE_NAME }}
 
 jobs:
   Run-Tests:

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@
 
 # files
 *.pyc
-.env
+.env*
 aux_methods/imdb_api_results.json
 update_showlist.py
 *.log

--- a/config.py
+++ b/config.py
@@ -7,6 +7,8 @@ from database.DatabaseService import DatabaseService
 
 if os.environ['PYTHON_ENV'] == 'testing':
     load_dotenv('.env.local.test')
+elif os.environ['PYTHON_ENV'] == 'development':
+    load_dotenv('.env.local.dev')
 else:
     load_dotenv('.env')
 

--- a/config.py
+++ b/config.py
@@ -5,13 +5,16 @@ import os
 
 from database.DatabaseService import DatabaseService
 
-load_dotenv('.env')
+if os.environ['PYTHON_ENV'] == 'testing':
+    load_dotenv('.env.local.test')
+else:
+    load_dotenv('.env')
 
 
 environment = os.getenv('PYTHON_ENV')
 
-database = 'tvguide' if environment == 'production' else 'development'
-database_connection = os.getenv('LOCAL_DB') if environment == 'development' else os.getenv('TVGUIDE_DB')
+database = os.getenv('DATABASE_NAME')
+database_connection = os.getenv('TVGUIDE_DB')
 database_service = DatabaseService(database_connection, database)
 
 scheduler = AsyncIOScheduler()

--- a/config.py
+++ b/config.py
@@ -13,8 +13,6 @@ else:
     load_dotenv('.env')
 
 
-environment = os.getenv('PYTHON_ENV')
-
 database = os.getenv('DATABASE_NAME')
 database_connection = os.getenv('TVGUIDE_DB')
 database_service = DatabaseService(database_connection, database)

--- a/database/DatabaseService.py
+++ b/database/DatabaseService.py
@@ -1,6 +1,5 @@
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.job import Job
-from pymongo.database import Database
 from pymongo.errors import OperationFailure
 from pymongo import ReturnDocument, DESCENDING
 from datetime import datetime

--- a/guide.py
+++ b/guide.py
@@ -198,7 +198,7 @@ def reminders(guide_list: list['GuideShow'], scheduler: AsyncIOScheduler = None)
                     send_message,
                     DateTrigger(run_date=reminder.notify_time, timezone='Australia/Sydney'),
                     [reminder.notification()],
-                    id=f'reminder-{reminder.show}',
+                    id=f'reminder-{reminder.show}-{Validation.get_current_date()}',
                     name=f'Send the reminder message for {reminder.show}'
                 )
         return reminders_message

--- a/guide.py
+++ b/guide.py
@@ -122,7 +122,7 @@ def search_bbc_australia():
 
     shows_on: list[GuideShow] = []
     for show in show_list:
-        guide_show = build_guide_show(show, database_service, show_list)
+        guide_show = build_guide_show(show, show_list)
         database_service.capture_db_event(guide_show)
         shows_on.append(guide_show)
 

--- a/guide.py
+++ b/guide.py
@@ -71,7 +71,7 @@ def search_free_to_air():
             if show_data['title'] == show['title']
             and show['season_number'] == 'Unknown'
         ]
-        guide_show = build_guide_show(show, database_service, unknown_episodes)
+        guide_show = build_guide_show(show, unknown_episodes)
         if 'HD' not in guide_show.channel:
             database_service.capture_db_event(guide_show)
         shows_on.append(guide_show)
@@ -120,11 +120,6 @@ def search_bbc_australia():
     search_channel_data(bbc_first_data, 'BBC First')
     search_channel_data(bbc_uktv_data, 'BBC UKTV')
 
-    shows_on = build_guide_shows(show_list, database_service)
-
-    return shows_on
-
-def build_guide_shows(show_list: list[dict], database_service: DatabaseService):
     shows_on: list[GuideShow] = []
     for show in show_list:
         guide_show = build_guide_show(show, database_service, show_list)
@@ -133,7 +128,7 @@ def build_guide_shows(show_list: list[dict], database_service: DatabaseService):
 
     return shows_on
 
-def build_guide_show(show: dict, database_service: DatabaseService, unknown_episodes: list[dict]):
+def build_guide_show(show: dict, unknown_episodes: list[dict]):
     episode_data = GuideShow.get_show(show['title'], show['season_number'], show['episode_number'], show['episode_title'])
     title, season_number, episode_number, episode_title = episode_data
     recorded_show = database_service.get_one_recorded_show(title)
@@ -186,7 +181,7 @@ def compose_message(fta_shows: list['GuideShow'], bbc_shows: list['GuideShow'], 
 
     return message
 
-def reminders(guide_list: list['GuideShow'], database_service: DatabaseService, scheduler: AsyncIOScheduler = None):
+def reminders(guide_list: list['GuideShow'], scheduler: AsyncIOScheduler = None):
     print('===================================================================================')
     print('Reminders:')
     for guide_show in guide_list:
@@ -228,10 +223,9 @@ def run_guide(fta_list: list['GuideShow'], bbc_list: list['GuideShow'], schedule
     print(guide_message)
     if update_db_flag:
         database_service.backup_recorded_shows()
-        
         database_service.add_guide_data(fta_list, bbc_list)
 
-    reminders_message = reminders(guide_list, database_service, scheduler)
+    reminders_message = reminders(guide_list, scheduler)
     return guide_message, reminders_message
 
 def revert_database_tvguide(database_service: DatabaseService):

--- a/guide.py
+++ b/guide.py
@@ -4,6 +4,7 @@ from requests import get
 import os
 
 from aux_methods.helper_methods import build_episode, convert_utc_to_local
+from config import database_service
 from data_validation.validation import Validation
 from database.DatabaseService import DatabaseService
 from database.models.GuideShow import GuideShow
@@ -17,7 +18,7 @@ def find_json(url):
     
     return request.json()
 
-def search_free_to_air(database_service: DatabaseService):
+def search_free_to_air():
     """
 
     :return:
@@ -77,7 +78,7 @@ def search_free_to_air(database_service: DatabaseService):
     
     return shows_on
 
-def search_bbc_australia(database_service: DatabaseService):
+def search_bbc_australia():
 
     current_date = Validation.get_current_date().date()
     search_date = current_date.strftime('%Y-%m-%d')
@@ -211,7 +212,7 @@ def reminders(guide_list: list['GuideShow'], database_service: DatabaseService, 
         print('===================================================================================')
         return 'There are no reminders scheduled for today'
 
-def run_guide(database_service: DatabaseService, fta_list: list['GuideShow'], bbc_list: list['GuideShow'], scheduler: AsyncIOScheduler=None):
+def run_guide(fta_list: list['GuideShow'], bbc_list: list['GuideShow'], scheduler: AsyncIOScheduler=None):
 
     latest_guide = database_service.get_latest_guide()
     if latest_guide:

--- a/local_guide.py
+++ b/local_guide.py
@@ -4,7 +4,6 @@ import click
 import os
 
 from database.DatabaseService import DatabaseService
-from services.hermes.hermes import hermes
 
 
 async def send_main_message(guide_message: str, reminder_message: str, events_message: str):
@@ -13,6 +12,7 @@ async def send_main_message(guide_message: str, reminder_message: str, events_me
     :param send_status:
     :return: n/a
     """
+    from services.hermes.hermes import hermes
     await hermes.wait_until_ready()
     tvguide_channel: TextChannel = hermes.get_channel(int(os.getenv('DEV_CHANNEL')))
     ngin = await hermes.fetch_user(int(os.getenv('NGIN')))
@@ -57,17 +57,20 @@ def tear_down_data(local_db: bool):
 @click.option('--discord', default=True, help='Whether to send the message via Discord')
 def run_guide(local_db: bool, discord: bool):
     from aux_methods.helper_methods import compose_events_message
-    from guide import run_guide, search_free_to_air, search_bbc_australia
+    from dotenv import load_dotenv
 
     if local_db:
-        database_connection = os.getenv('LOCAL_DB')
+        os.environ['PYTHON_ENV'] = 'development'
+        load_dotenv('.env.local.dev')
     else:
-        database_connection = os.getenv('TVGUIDE_DB')
-    database_service = DatabaseService(database_connection, 'development')
+        os.environ['PYTHON_ENV'] = 'production'
+    
+    from guide import run_guide, search_free_to_air, search_bbc_australia
+    from services.hermes.hermes import hermes
 
-    fta_list = search_free_to_air(database_service)
-    bbc_list = search_bbc_australia(database_service)
-    guide_message, reminders_message = run_guide(database_service, fta_list, bbc_list)
+    fta_list = search_free_to_air()
+    bbc_list = search_bbc_australia()
+    guide_message, reminders_message = run_guide(fta_list, bbc_list)
     events_message = compose_events_message(fta_list + bbc_list)
     if discord:
         try:

--- a/local_guide.py
+++ b/local_guide.py
@@ -75,6 +75,7 @@ def run_guide(local_db: bool, discord: bool):
     if discord:
         try:
             hermes.loop.create_task(send_main_message(guide_message, reminders_message, events_message))
+            hermes.run(os.getenv('HERMES'))
         except ClientConnectorError:
             print(guide_message)
             print(reminders_message)

--- a/main.py
+++ b/main.py
@@ -6,8 +6,7 @@ from requests import get
 import os
 
 from aux_methods.helper_methods import compose_events_message, split_message_by_time
-from config import database_service, scheduler
-from database.DatabaseService import DatabaseService
+from config import scheduler
 from guide import run_guide, search_free_to_air, search_bbc_australia
 from services.hermes.hermes import hermes
 
@@ -38,15 +37,15 @@ def search_vera_series():
     return series_num
 
 
-async def send_main_message(database_service: DatabaseService):
+async def send_main_message():
     """
 
     :param `database_service`: The service handler for database operations
     :return: n/a
     """
-    fta_list = search_free_to_air(database_service)
-    bbc_list = search_bbc_australia(database_service)
-    guide_message, reminder_message = run_guide(database_service, fta_list, bbc_list, scheduler)
+    fta_list = search_free_to_air()
+    bbc_list = search_bbc_australia()
+    guide_message, reminder_message = run_guide(fta_list, bbc_list, scheduler)
     
     await hermes.wait_until_ready()
     tvguide_channel: TextChannel = hermes.get_channel(int(os.getenv('TVGUIDE_CHANNEL')))
@@ -84,7 +83,6 @@ if __name__ == '__main__':
     scheduler.add_job(
         send_main_message,
         CronTrigger(hour=9, timezone='Australia/Sydney'),
-        [database_service],
         id='TVGuide Message',
         name='Send the TVGuide message',
         misfire_grace_time=None,

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from dotenv import load_dotenv
 from requests import get
 import os
 
+os.environ['PYTHON_ENV'] = 'production'
 from aux_methods.helper_methods import compose_events_message, split_message_by_time
 from config import scheduler
 from guide import run_guide, search_free_to_air, search_bbc_australia

--- a/services/hermes/commands.py
+++ b/services/hermes/commands.py
@@ -45,9 +45,9 @@ async def remove_show(ctx: Context, show: str):
 
 @hermes.command()
 async def send_guide(ctx: Context):
-    fta_list = search_free_to_air(database_service)
-    bbc_list = search_bbc_australia(database_service)
-    guide_message, reminders_message = run_guide(database_service, fta_list, bbc_list, scheduler)
+    fta_list = search_free_to_air()
+    bbc_list = search_bbc_australia()
+    guide_message, reminders_message = run_guide(fta_list, bbc_list, scheduler)
     ngin = await hermes.fetch_user(int(os.getenv('NGIN')))
     try:
         await ctx.send(guide_message)

--- a/services/hermes/hermes.py
+++ b/services/hermes/hermes.py
@@ -1,7 +1,11 @@
 from discord.ext.commands import Bot, DefaultHelpCommand
 from dotenv import load_dotenv
+import os
 
-load_dotenv('.env')
+if os.environ['PYTHON_ENV'] == 'production':
+    load_dotenv('.env')
+else:
+    load_dotenv('.env.local.dev')
 hermes = Bot(command_prefix='$', help_command=DefaultHelpCommand())
 
 

--- a/services/hermes/hermes.py
+++ b/services/hermes/hermes.py
@@ -1,11 +1,5 @@
 from discord.ext.commands import Bot, DefaultHelpCommand
-from dotenv import load_dotenv
-import os
 
-if os.environ['PYTHON_ENV'] == 'production':
-    load_dotenv('.env')
-else:
-    load_dotenv('.env.local.dev')
 hermes = Bot(command_prefix='$', help_command=DefaultHelpCommand())
 
 

--- a/services/hermes/utilities.py
+++ b/services/hermes/utilities.py
@@ -4,10 +4,14 @@ import os
 from services.hermes.hermes import hermes
 
 async def send_message(message: str):
-    tvguide_channel: TextChannel = hermes.get_channel(int(os.getenv('TVGUIDE_CHANNEL')))
+    if os.getenv('PYTHON_ENV') == 'development' or os.getenv('PYTHON_ENV') == 'testing':
+        channel_id = int(os.getenv('DEV_CHANNEL'))
+    else:
+        channel_id = int(os.getenv('TVGUIDE_CHANNEL'))
     await hermes.wait_until_ready()
-    if tvguide_channel is not None:
-        await tvguide_channel.send(message)
+    channel: TextChannel = hermes.get_channel(channel_id)
+    if channel is not None:
+        await channel.send(message)
     else:
         ngin = await hermes.fetch_user(int(os.getenv('NGIN')))
         await ngin.send(f'{message}\nHermes was also unable to send this message through the TVGuide channel')

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -18,7 +18,7 @@ class TestDatabase(unittest.TestCase):
     @classmethod
     def setUpClass(self) -> None:
         super().setUpClass()
-        load_dotenv('.env')
+        load_dotenv('.env.local.test')
         os.environ['PYTHON_ENV'] = 'testing'
         self.database_service = DatabaseService(os.getenv('TVGUIDE_DB'), 'test')
 

--- a/tests/test_guide.py
+++ b/tests/test_guide.py
@@ -1,12 +1,10 @@
 from unittest.mock import Mock, patch, MagicMock
 from datetime import datetime
-from dotenv import load_dotenv
 from textwrap import dedent
 import unittest
 import json
 import os
 
-load_dotenv('.env.local.test')
 os.environ['PYTHON_ENV'] = 'testing'
 
 from config import database_service

--- a/tests/test_guide.py
+++ b/tests/test_guide.py
@@ -6,7 +6,10 @@ import unittest
 import json
 import os
 
-from database.DatabaseService import DatabaseService
+load_dotenv('.env.local.test')
+os.environ['PYTHON_ENV'] = 'testing'
+
+from config import database_service
 from database.models.Reminders import Reminder
 from guide import search_free_to_air, compose_message, reminders
 
@@ -16,9 +19,7 @@ requests = Mock()
 class TestGuide(unittest.TestCase):
 
     def setUp(self):
-        load_dotenv('.env')
-        os.environ['PYTHON_ENV'] = 'testing'
-        self.database_service = DatabaseService(os.getenv('TVGUIDE_DB'), 'test')
+        self.database_service = database_service
 
         with open('tests/test_data/reminders_data.json') as fd:
             reminders_data = json.load(fd)
@@ -46,7 +47,7 @@ class TestGuide(unittest.TestCase):
         mocked_today = datetime(2023, 10, 30)
         mock_datetime.now.return_value = mocked_today
         
-        data = search_free_to_air(self.database_service)
+        data = search_free_to_air()
         
         guide_show_all_details = data[0]
         self.assertEqual(4, guide_show_all_details.season_number)
@@ -59,7 +60,7 @@ class TestGuide(unittest.TestCase):
         mocked_today = datetime(2023, 10, 30)
         mock_datetime.now.return_value = mocked_today
         
-        data = search_free_to_air(self.database_service)
+        data = search_free_to_air()
         
         guide_show_episode_num = data[1]
         self.assertEqual(4, guide_show_episode_num.season_number)
@@ -72,7 +73,7 @@ class TestGuide(unittest.TestCase):
         mocked_today = datetime(2023, 10, 30)
         mock_datetime.now.return_value = mocked_today
         
-        data = search_free_to_air(self.database_service)
+        data = search_free_to_air()
         
         guide_show_episode_title = data[3]
         self.assertEqual('Unknown', guide_show_episode_title.season_number)
@@ -85,7 +86,7 @@ class TestGuide(unittest.TestCase):
         mocked_today = datetime(2023, 10, 30)
         mock_datetime.now.return_value = mocked_today
         
-        data = search_free_to_air(self.database_service)
+        data = search_free_to_air()
         
         guide_show_episode_title = data[4]
         self.assertEqual('Unknown', guide_show_episode_title.season_number)
@@ -94,7 +95,7 @@ class TestGuide(unittest.TestCase):
 
     @patch('guide.get', return_value=guide_data())
     def test_search_is_sorted(self, mock_requests):
-        data = search_free_to_air(self.database_service)
+        data = search_free_to_air()
 
         self.assertTrue(all(data[i].time <= data[i+1].time for i in range(len(data) - 1)))
     
@@ -104,7 +105,7 @@ class TestGuide(unittest.TestCase):
         mocked_today = datetime(2023, 10, 30)
         mock_datetime.now.return_value = mocked_today
         
-        data = search_free_to_air(self.database_service)
+        data = search_free_to_air()
         message = compose_message(data, [])
 
         self.assertIn('30-10-2023', message)
@@ -113,7 +114,7 @@ class TestGuide(unittest.TestCase):
     def test_message_contains_date_provided(self, mock_requests):
         date_provided = datetime(2023, 11, 4)
         
-        data = search_free_to_air(self.database_service)
+        data = search_free_to_air()
         message = compose_message(data, [], date_provided)
 
         self.assertIn('04-11-2023', message)
@@ -129,7 +130,7 @@ class TestGuide(unittest.TestCase):
         mocked_today = datetime(2023, 10, 30)
         mock_datetime.now.return_value = mocked_today
 
-        data = search_free_to_air(self.database_service)
+        data = search_free_to_air()
         message = compose_message(data, [])
 
         expected = """
@@ -159,8 +160,8 @@ class TestGuide(unittest.TestCase):
         mocked_today = datetime(2023, 10, 30)
         mock_datetime.now.return_value = mocked_today
 
-        data = search_free_to_air(self.database_service)
-        reminders_message = reminders(data, self.database_service)
+        data = search_free_to_air()
+        reminders_message = reminders(data)
 
         self.assertIn('REMINDER: Doctor Who is on ABC1 at 00:00', reminders_message)
         self.assertIn('REMINDER: Doctor Who is on ABC1 at 00:45', reminders_message)

--- a/tests/test_guide_show.py
+++ b/tests/test_guide_show.py
@@ -14,7 +14,7 @@ from exceptions.DatabaseError import EpisodeNotFoundError, SeasonNotFoundError, 
 class TestGuideShow(unittest.TestCase):
 
     def setUp(self):
-        load_dotenv('.env')
+        load_dotenv('.env.local.test')
         self.database_service = DatabaseService(os.getenv('TVGUIDE_DB'), 'test')
         with open('tests/test_data/test_guide_list.json') as fd:
             self.data = json.load(fd)

--- a/tests/test_search_conditions.py
+++ b/tests/test_search_conditions.py
@@ -13,7 +13,7 @@ class TestSearchConditions(unittest.TestCase):
     @classmethod
     def setUpClass(self) -> None:
         super().setUpClass()
-        load_dotenv('.env')
+        load_dotenv('.env.local.test')
         os.environ['PYTHON_ENV'] = 'testing'
 
         self.database_service = DatabaseService(os.getenv('TVGUIDE_DB'), 'test')


### PR DESCRIPTION
### Ticket
[TVG-34](https://natalie-g-projects.atlassian.net/browse/TVG-34)

### Description
When attempting to deploy the changes with the newly added MongoDBJobStore, there was an issue running the TVGuide as the `SSLContext` object could not be pickled. Through investigation, this was found to be caused by adding the `database_service` object as an argument to the Send TVGuide message job.

This PR ensures that the guide module can still perform its necessary functions without having to pass in the `database_service` object as an argument to all functions. In addition, changes also had to be made so that the TVGuide can still be run locally and tests can still be performed as expected.

### ENV variable changes
- Created an `env.local.dev` and `env.local.test` file
- Added DATABASE_NAME

[TVG-34]: https://natalie-g-projects.atlassian.net/browse/TVG-34?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ