### PR TITLE
[TVG-37] Serve TVGuide API & Hermes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /database/backups
 /database/restore
 /dev-data/mongo_data
+/build
 
 # files
 *.pyc

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 # TODO: Modify this Procfile to fit your needs
 worker: python main.py
-<!-- web: gunicorn api:app -->
+web: gunicorn api:app

--- a/api.py
+++ b/api.py
@@ -1,9 +1,13 @@
-from flask import Flask, request
+from flask import Flask, request, render_template, send_from_directory
 from flask_cors import CORS
 from flask_jwt_extended import create_access_token, JWTManager, jwt_required, get_current_user
 import sys
 import os
 
+if len(sys.argv) > 1:
+    os.environ['PYTHON_ENV'] = sys.argv[1]
+else:
+    os.environ['PYTHON_ENV'] = 'production'
 from config import database_service
 from database.models.RecordedShow import RecordedShow, Season, Episode
 from database.models.Reminders import Reminder
@@ -18,7 +22,7 @@ from exceptions.DatabaseError import (
 )
 from services.tvmaze.tvmaze_api import get_show_data
 
-app = Flask(__name__)
+app = Flask(__name__, template_folder='build', static_folder='build/static')
 CORS(app)
 app.config['JWT_SECRET_KEY'] = os.getenv('JWT_SECRET')
 jwt = JWTManager(app)
@@ -29,6 +33,18 @@ jwt = JWTManager(app)
 @jwt.user_lookup_loader
 def user_lookup_callback(_jwt_header, jwt_data):
     return database_service.get_user(jwt_data['sub'])
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/favicon.ico')
+def favicon():
+    return send_from_directory('build', 'favicon.ico')
+
+@app.route('/manifest.json')
+def manifest():
+    return send_from_directory('build', 'manifest.json')
 
 # SEARCH LIST
 @app.route('/api/show-list', methods=['GET'])
@@ -297,10 +313,6 @@ def events():
     return events
 
 if __name__ == '__main__':
-    if len(sys.argv) > 1:
-        os.environ['PYTHON_ENV'] = sys.argv[1]
-    else:
-        os.environ['PYTHON_ENV'] = 'production'
     if os.getenv('PYTHON_ENV') == 'production':
         host = 'tvguide-ng.fly.dev'
         debug = False

--- a/api.py
+++ b/api.py
@@ -300,5 +300,11 @@ if __name__ == '__main__':
     if len(sys.argv) > 1:
         os.environ['PYTHON_ENV'] = sys.argv[1]
     else:
-        os.environ['PYTHON_ENV'] = 'production'        
-    app.run(host='0.0.0.0', port='5000', debug=True)
+        os.environ['PYTHON_ENV'] = 'production'
+    if os.getenv('PYTHON_ENV') == 'production':
+        host = 'tvguide-ng.fly.dev'
+        debug = False
+    else:
+        host = '0.0.0.0'
+        debug = True
+    app.run(host=host, port='5000', debug=debug)

--- a/fly.toml
+++ b/fly.toml
@@ -6,5 +6,18 @@
 app = "tvguide-ng"
 primary_region = "syd"
 
+[processes]
+worker = "python main.py"
+web = "gunicorn api:app"
+
+[env]
+  PORT = 5000
+
+[http_service]
+  processes = ["web"]
+  internal_port = 5000
+
+
+
 [build]
   builder = "paketobuildpacks/builder:base"

--- a/tests/test_guide.py
+++ b/tests/test_guide.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock, patch, MagicMock
 from datetime import datetime
+from dotenv import load_dotenv
 from textwrap import dedent
 import unittest
 import json
@@ -7,8 +8,8 @@ import os
 
 os.environ['PYTHON_ENV'] = 'testing'
 
-from config import database_service
 from database.models.Reminders import Reminder
+from database import DatabaseService
 from guide import search_free_to_air, compose_message, reminders
 
 requests = Mock()
@@ -17,7 +18,9 @@ requests = Mock()
 class TestGuide(unittest.TestCase):
 
     def setUp(self):
-        self.database_service = database_service
+        super().setUpClass()
+        load_dotenv('.env.local.test')
+        self.database_service = DatabaseService(os.getenv('TVGUIDE_DB'), 'test')
 
         with open('tests/test_data/reminders_data.json') as fd:
             reminders_data = json.load(fd)

--- a/tests/test_guide.py
+++ b/tests/test_guide.py
@@ -9,7 +9,7 @@ import os
 os.environ['PYTHON_ENV'] = 'testing'
 
 from database.models.Reminders import Reminder
-from database import DatabaseService
+from database.DatabaseService import DatabaseService
 from guide import search_free_to_air, compose_message, reminders
 
 requests = Mock()


### PR DESCRIPTION
### Ticket
[TVG-37](https://natalie-g-projects.atlassian.net/browse/TVG-37)

### Description
Ensure that the production environment is capable of serving the API, the frontend and Hermes at the same time

### ENV variable changes
JWT_SECRET = `TVGuideByNGinA` (set on next deploy)

[TVG-37]: https://natalie-g-projects.atlassian.net/browse/TVG-37?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ