### PR TITLE
TVG-46

### DIFF
--- a/database/models/GuideShow.py
+++ b/database/models/GuideShow.py
@@ -129,7 +129,8 @@ class GuideShow:
                     DateTrigger(run_date=reminder.notify_time, timezone='Australia/Sydney'),
                     [reminder.notification()],
                     id=f'reminder-{reminder.show}-{Validation.get_current_date()}',
-                    name=f'Send the reminder message for {reminder.show}'
+                    name=f'Send the reminder message for {reminder.show}',
+                    misfire_grace_time=None
                 )
 
     def message_string(self):


### PR DESCRIPTION
### Ticket
TVG-46

### Description
The Reminders scheduled jobs did not have the `misfire_grace_time` allowance added to the job. This meant that there could be some occasions where the Reminder would not be sent.

This PR adds the `misfire_grace_time` to the job

### ENV variable changes
None