### PR TITLE
TVG-48 Parse episode time to datetime object when retrieved from DB

### DIFF
--- a/database/models/Guide.py
+++ b/database/models/Guide.py
@@ -23,6 +23,10 @@ class Guide:
     @classmethod
     def from_database(cls, guide_details: dict, database_service: DatabaseService = None):
         datetime_stamp = datetime.strptime(guide_details['date'], '%d/%m/%Y')
+        for show in guide_details['FTA']:
+            show['time'] = datetime.strptime(f"{guide_details['date']}T{show['time']}", '%d/%m/%YT%H:%M')
+        for show in guide_details['BBC']:
+            show['time'] = datetime.strptime(f"{guide_details['date']}T{show['time']}", '%d/%m/%YT%H:%M')
 
         fta_list = [Guide.build_guide_show(show, [], database_service) for show in guide_details['FTA']]
         bbc_list = [Guide.build_guide_show(show, [], database_service) for show in guide_details['BBC']]


### PR DESCRIPTION
### Ticket
[TVG-48](https://natalie-g-projects.atlassian.net/browse/TVG-48)

### Description
When the Guide is retrieved from the database and GuideShows from that guide record are built, the times of each episode are string types. The GuideShow construtor expects these to be datetime type. Since the value is of the wrong type, it cannot be formatted properly when the frontend tries to retrieve a JSON interpretation of the Guide record. This prevents it from being sent to the frontend.

### ENV variable changes
None

[TVG-48]: https://natalie-g-projects.atlassian.net/browse/TVG-48?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ