### PR TITLE
[TVG-74] Reminder not returned with shows data

### DIFF
--- a/api.py
+++ b/api.py
@@ -49,7 +49,8 @@ def shows():
             "show_name": show.title,
             "show_details": show.to_dict(),
             "search_item": show.search.to_dict() if show.search else None,
-            "show_episodes": [episode.to_dict() for episode in show.show_episodes]
+            "show_episodes": [episode.to_dict() for episode in show.show_episodes],
+            "reminder": show.reminder.to_dict() if show.reminder else None
         }
         show_data.append(show_json)
     return show_data


### PR DESCRIPTION
### Ticket
[TVG-74](https://natalie-g-projects.atlassian.net/browse/TVG-74)

### Description
Reminders that have been set for a show are not returned in the endpoint handling fetching show data. Returning the reminder with the show reduces the need for an additional request to retrieve all reminders.

### ENV variable changes
None

[TVG-74]: https://natalie-g-projects.atlassian.net/browse/TVG-74?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ