### PR TITLE
TVG-81 Add ShowDetails id to new Reminders

### DIFF
--- a/api.py
+++ b/api.py
@@ -270,7 +270,13 @@ def reminders():
         return {'message': f'{show} is not being searched for'}, 400
     if reminder_check:
         return {'message': f'A reminder already exists for {show}'}, 409
-    new_reminder = Reminder(show, body['alert'], body['warning_time'], body['occasions'])
+    new_reminder = Reminder(
+        show,
+        body['alert'],
+        body['warning_time'],
+        body['occasions'],
+        show_check.id
+    )
     try:
         new_reminder.add_reminder(session)
         return {


### PR DESCRIPTION
### Ticket
[TVG-81](https://natalie-g-projects.atlassian.net/browse/TVG-81)

### Description
- The id of ShowDetails records weren't added to new Reminders created via the API. This means that the reminder won't be returned when the show is later pulled from the API.
- This PR adds the id to the initialised object.

### ENV variable changes
None

[TVG-81]: https://natalie-g-projects.atlassian.net/browse/TVG-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ